### PR TITLE
Ajustando no cadastro de mentor caso o usuario nao selecione nada

### DIFF
--- a/src/components/RedeSelect/RedeSelect.jsx
+++ b/src/components/RedeSelect/RedeSelect.jsx
@@ -15,6 +15,7 @@ const RedeSelect = ({
   <Container>
     <TextField.Label>Áreas de Conhecimento</TextField.Label>
     <Select onChange={onChange}>
+      <option value="" disabled selected={(!select)}>Selecione...</option>
       {
           options.map((element) => ((select === element)
             ? <option value={element} selected>{element}</option>

--- a/src/components/RedeSelect/RedeSelect.jsx
+++ b/src/components/RedeSelect/RedeSelect.jsx
@@ -18,7 +18,7 @@ const RedeSelect = ({
       {
           options.map((element) => ((select === element)
             ? <option value={element} selected>{element}</option>
-            : <option value={element}>{element}</option>))
+            : <option value={element} disabled={((element === ''))}>{element}</option>))
       }
 
     </Select>

--- a/src/pages/cadastro-mentor/CadastroMentor.jsx
+++ b/src/pages/cadastro-mentor/CadastroMentor.jsx
@@ -44,7 +44,7 @@ function CadastroMentor() {
       res.data.forEach((area) => {
         arrayAreas.push(area.name);
       });
-      setAvailableAreas(['', ...arrayAreas]);
+      setAvailableAreas(arrayAreas);
     });
 
 

--- a/src/pages/cadastro-mentor/CadastroMentor.jsx
+++ b/src/pages/cadastro-mentor/CadastroMentor.jsx
@@ -44,7 +44,7 @@ function CadastroMentor() {
       res.data.forEach((area) => {
         arrayAreas.push(area.name);
       });
-      setAvailableAreas(arrayAreas);
+      setAvailableAreas(['', ...arrayAreas]);
     });
 
 


### PR DESCRIPTION
Quando o usuário não selecionava nenhuma area de conhecimento dava erro na hora de cadastrar.

Quando ele cai na tela agora, tem uma opção vazia em que ele é obrigado a selecionar uma area de conhecimento