### PR TITLE
Correcao de centralizacao de botoes nas telas de cadastroMentoria e as modais de Adm

### DIFF
--- a/src/components/RedeButton/StyledComponents/Cancelar.jsx
+++ b/src/components/RedeButton/StyledComponents/Cancelar.jsx
@@ -6,7 +6,6 @@ const Cancelar = css`
   color: ${COLOR.AZUL};
   background-color: ${COLOR.BRANCO};
   border: solid 1px ${COLOR.AZUL};
-  margin: 10px 40px;
 
   :hover {
     color: ${COLOR.BRANCO};

--- a/src/pages/adm/StyledComponents/ButtonWrapper.jsx
+++ b/src/pages/adm/StyledComponents/ButtonWrapper.jsx
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  place-content: center;
+
+  width: 100%;
+
+  position: relative;  
+  button{
+    margin-left:10px;
+    margin-right:10px;
+  }
+  @media only screen and (max-width: 768px) {
+    width: 100%;
+    padding: 0px;
+  }
+`;
+
+export default ButtonWrapper;

--- a/src/pages/adm/StyledComponents/Modal.jsx
+++ b/src/pages/adm/StyledComponents/Modal.jsx
@@ -4,6 +4,7 @@ import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
+import ButtonWrapper from './ButtonWrapper';
 import RedeTextField from '../../../components/RedeTextField/RedeTextField';
 import RedeButton from '../../../components/RedeButton/RedeButton';
 
@@ -31,15 +32,17 @@ const Modal = ({
         />
       </DialogContent>
       <DialogActions>
-        <RedeButton
-          descricao="Cancelar"
-          onClick={handleClose}
-          cancelar
-        />
-        <RedeButton
-          descricao="Aprovar"
-          onClick={editFunction}
-        />
+        <ButtonWrapper>
+          <RedeButton
+            descricao="Cancelar"
+            onClick={handleClose}
+            cancelar
+          />
+          <RedeButton
+            descricao="Aprovar"
+            onClick={editFunction}
+          />
+        </ButtonWrapper>
       </DialogActions>
     </Dialog>
   </div>

--- a/src/pages/cadastro-mentoria/CadastroMentoria.jsx
+++ b/src/pages/cadastro-mentoria/CadastroMentoria.jsx
@@ -316,7 +316,6 @@ function CadastroMentoria() {
           </DivSelect>
         </Container.SecondOption>
       </Container.Form>
-
       <Container.Submit>
         <RedeButton descricao="Cancelar" cancelar onClick={(e) => cleanForm(e)} />
         <RedeButton descricao={ActionButtonTitle} onClick={handleAddMentoria} />

--- a/src/pages/cadastro-mentoria/StyledComponents/Submit.jsx
+++ b/src/pages/cadastro-mentoria/StyledComponents/Submit.jsx
@@ -1,10 +1,11 @@
 import styled from 'styled-components';
 
 const Submit = styled.div`
+  margin:0 auto;
+  width:85%;
   display: flex;
   align-items: center;
-  justify-content: center;
-  margin-left: 15px;
+  justify-content: space-evenly;
 
   @media only screen and (max-width: 1024px) {
     flex-direction: column;


### PR DESCRIPTION
Centralização nas duas modais da tela ADM;
Tirei uma margin do style de _cancelar_ do redeButton, e centralizei onde o botão com cancelar aparecia(cadastroMentoria);